### PR TITLE
Release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,48 +3,29 @@ A Node.js REST client for VPS admin.
 This is a wrapper around [node-libcurl](https://github.com/JCMais/node-libcurl) focusing on consuming VPS REST API.
 
 ### Install
-```[sudo] npm install [-g] vps-rest-client```
+```npm i [-g] vps-rest-client```
 
-### Simple GET
+### Example
 ```javascript
-var host = 'https://api.budgetvm.com/v2/dns/record';
-var key = 'some___key';
-var domain_id = 'some___id';
+const Client = require('vps-rest-client');
 
-var rest = require('vps-rest-client');
-var client = rest.createClient(key, {
-  verbose: false
-});
+var host = 'https://api.linode.com/v4/domains';
+var token = '....';
+var domain = 'foo-domain.com';
+var post = { domain: 'mynewdomain2.com' };
+var change = { soa_email: 'newemail@example.com' };
 
-client.get(host + '/' + domain_id).then(function(response) {
-  console.info(response);
-  client.close();
-}).catch((err) => console.info(err));
+const client = new Client(token);
 
-```
-
-### Make a POST and when done, make a GET
-```javascript
-var post = {
-  domain: domain_id,
-  record: 'test.example.net',
-  type: 'A',
-  content: '111.111.111.111'
-};
-
-client.post(host, post).then(function(resp) {
-  console.info(resp);
-  
-  if (resp.success === true) {
-    client.get(host + '/' + domain_id).then(function(response) {
-      console.info(response);
-      client.close();
-    });
-  } else {
-    client.close();
-  }
-}).catch((err) => console.info(err));
-
+client.GET(host)
+  .then(res => res.data.find(o => o.domain === domain).id)
+  .then(id => client.POST(`${host}/${id}/clone`, post))
+  .then(res => res.id)
+  .then(id => client.PUT(`${host}/${id}`, change))
+  .then(res => res.id)
+  .then(id => client.DELETE(`${host}/${id}`))
+  .then(console.log)
+  .catch(console.log);
 ```
 
 ## Friendly response
@@ -55,10 +36,11 @@ That way you can interact with the responses using JavaScript syntax.
 
 ## Constructor
 
-#### `createClient(key, options)`
-`@param {String} key` API required key.
+#### `new Client(token, options)`
+`@param {String} token` API required token or key.
 
 `@param {Object|undefined} options` An object with the following possible properties:
+* `dataFormat`: *`'JSON'`*; The API (payload) data format, could be *`'URI'`*
 * `verbose`: *`true`*
 
 ## Methods
@@ -78,32 +60,6 @@ Returns a promise for the request.
 `@param {Object} data` Data to be posted.
 Returns a promise for the request.
 
-#### client.delete(url, data)
+#### client.delete(url)
 `@param {String} url` API url.
-`@param {Object} data` Data to be posted.
 Returns a promise for the request.
-
-
-## Change Log
-
-### upcoming (2015/11/09 11:43 +00:00)
-- [f51ccfe](https://github.com/jonataswalker/vps-rest-client/commit/f51ccfe899dcfbc579a7d81d0f0173814873c909) Bump v0.1.3 (@jonataswalker)
-
-### 0.1.3 (2015/11/09 10:37 +00:00)
-- [dc8f2a0](https://github.com/jonataswalker/vps-rest-client/commit/dc8f2a005bbfd62dfaca675423ce3fddbc6e0a28) Add some more description. (@jonataswalker)
-- [c4935a9](https://github.com/jonataswalker/vps-rest-client/commit/c4935a982f538fd343f77c11818f28d68d8c0c7c) Added method docs (@jonataswalker)
-- [6d73ab3](https://github.com/jonataswalker/vps-rest-client/commit/6d73ab332be243c194f9850080ba47306ebc1491) Add some more description. (@jonataswalker)
-- [a9bab00](https://github.com/jonataswalker/vps-rest-client/commit/a9bab00e04da177ab66364c8fe72787e9aed4b28) Add some more description. (@jonataswalker)
-
-### 0.1.2 (2015/11/08 20:08 +00:00)
-- [ed08054](https://github.com/jonataswalker/vps-rest-client/commit/ed08054740fa6993a75f43a636b13c1a084992b9) Adjust package.json (@jonataswalker)
-
-### 0.1.1 (2015/11/08 19:58 +00:00)
-- [7305961](https://github.com/jonataswalker/vps-rest-client/commit/73059619772414b4ed79cf5c16a71c8295fac4e2) Adjust package.json (@jonataswalker)
-- [e063f64](https://github.com/jonataswalker/vps-rest-client/commit/e063f64e85768617ee922849025f3c492b7ab84d) Adjust package.json (@jonataswalker)
-- [aa02467](https://github.com/jonataswalker/vps-rest-client/commit/aa02467edc040fd49cdf03f5cd7f813f0a2f9e73) Add some more description. (@jonataswalker)
-- [5499711](https://github.com/jonataswalker/vps-rest-client/commit/54997115eb512f53caa28523ae5ca72394e82dfb) Initial release (@jonataswalker)
-
-### 0.1.0 (2015/11/07 12:48 +00:00)
-- [54857f7](https://github.com/jonataswalker/vps-rest-client/commit/54857f7aa176e617ce30f1c588bceef6342fcc83) Update README.md (@jonataswalker)
-- [de40b52](https://github.com/jonataswalker/vps-rest-client/commit/de40b52e001d6debc1c06f01570daec7a9e99a80) Initial commit (@jonataswalker)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vps-rest-client",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "A Node.js REST client for VPS admin",
   "main": "index.js",
   "repository": {
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/jonataswalker/vps-rest-client#readme",
   "scripts": {
     "lint": "eslint . --cache",
-    "test": "ava --verbose"
+    "test": "npm run lint && ava --verbose"
   },
   "dependencies": {
     "node-libcurl": "^1.3.0"


### PR DESCRIPTION
**Breaking:** There's no more `createClient`, see #3.

Now this is the way to go:

```javascript
const Client = require('vps-rest-client');

var host = 'https://api.linode.com/v4/domains';
var token = '....';

const client = new Client(token);
```